### PR TITLE
docs: add a simple README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# SSLKEYLOGFILE Extension for Encrypted Client Hello (ECH)
+
+This repository contains sample PCAPs and `SSLKEYLOGFILE` files for TLS
+handshakes using Encrypted Client Hello (ECH).
+
+In addition to the usual `SSLKEYLOGFILE` handshake traffic secrets the
+key log data is augmented with ECH configuration and derived secret based on
+[draft-rosomakho-tls-ech-keylogfile].
+
+[draft-rosomakho-tls-ech-keylogfile]: https://datatracker.ietf.org/doc/draft-rosomakho-tls-ech-keylogfile/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SSLKEYLOGFILE Extension for Encrypted Client Hello (ECH)
 
-This repository contains sample PCAPs and `SSLKEYLOGFILE` files for TLS
+This repository contains sample PCAPs and `SSLKEYLOGFILE` file with TLS
 handshakes using Encrypted Client Hello (ECH).
 
 In addition to the usual `SSLKEYLOGFILE` handshake traffic secrets the


### PR DESCRIPTION
Most importantly, link to the draft that describes the `SSLKEYLOGFILE` additions of interest.